### PR TITLE
Fix typo when testing if we can compile a file

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -134,7 +134,7 @@ function toDirectory (paths, dir) {
     }
 
     // if we can't compile it...
-    if (file.isNull() || canCompile(filePath)) {
+    if (file.isNull() || !canCompile(filePath)) {
       logFile(oldPath, newPath)
       this.push(file)
       return next(null)


### PR DESCRIPTION
hey @ahdinosaur directory cli use case is currently broken :-O. Here is a little fix.

Actually, I thought transpilify could have some unit tests for `cli.js` but I'm not sure how you would want to do it. Should I call `cli.js` with `child-process` directly and compare output files? WDYT?