### PR TITLE
use default flush (don't emit `end` event)

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -120,7 +120,7 @@ function toDirectory (paths, dir) {
   var rootDir = paths[0]
   var globs = [ path.join(rootDir, '/**/*') ]
   vinylfs.src(globs)
-    .pipe(through2.obj(write, flush))
+    .pipe(through2.obj(write))
     .pipe(vinylfs.dest(dir))
 
   function write (file, enc, next) {
@@ -156,11 +156,6 @@ function toDirectory (paths, dir) {
         stream.push(file)
         next(null)
       }))
-  }
-
-  function flush () {
-    this.push(null)
-    this.emit('end')
   }
 }
 


### PR DESCRIPTION
it seems this was causing the stream to end early.

fixes https://github.com/ahdinosaur/transpilify/issues/6

/cc @autra